### PR TITLE
Improve `SendPaymentResult` and test `PayInvoiceResponse.parse`

### DIFF
--- a/app/src/main/java/xyz/lilsus/papp/data/repository/blink/BlinkWalletRepository.kt
+++ b/app/src/main/java/xyz/lilsus/papp/data/repository/blink/BlinkWalletRepository.kt
@@ -10,6 +10,7 @@ import xyz.lilsus.papp.data.repository.blink.dto.PayInvoiceResponse
 import xyz.lilsus.papp.data.repository.blink.dto.parse
 import xyz.lilsus.papp.data.repository.blink.graphql.Mutations
 import xyz.lilsus.papp.domain.model.SendPaymentResult
+import xyz.lilsus.papp.domain.model.config.WalletTypeEntry
 import xyz.lilsus.papp.domain.repository.GraphQLHttpClient
 import xyz.lilsus.papp.domain.repository.WalletRepository
 
@@ -24,9 +25,12 @@ class BlinkWalletRepository(
     private val json: Json = Json { ignoreUnknownKeys = true }
 ) :
     WalletRepository {
+        
     companion object {
         const val GRAPHQL_URL = "https://api.blink.sv/graphql"
     }
+
+    override val walletType = WalletTypeEntry.BLINK
 
     override suspend fun payBolt11Invoice(invoice: Invoice): SendPaymentResult {
         val variables = buildJsonObject {

--- a/app/src/main/java/xyz/lilsus/papp/domain/model/SendPaymentData.kt
+++ b/app/src/main/java/xyz/lilsus/papp/domain/model/SendPaymentData.kt
@@ -1,7 +1,5 @@
 package xyz.lilsus.papp.domain.model
 
-import xyz.lilsus.papp.domain.model.config.WalletTypeEntry
-
 data class SendPaymentData(
     val amountPaid: Int,
     val feePaid: Int,
@@ -9,8 +7,8 @@ data class SendPaymentData(
 )
 
 sealed class SendPaymentResult {
-    class Success(wallet: WalletTypeEntry, val data: SendPaymentData) : SendPaymentResult()
-    class AlreadyPaid(wallet: WalletTypeEntry) : SendPaymentResult()
-    class Pending(wallet: WalletTypeEntry) : SendPaymentResult()
-    class Failure(wallet: WalletTypeEntry, val message: String) : SendPaymentResult()
+    class Success(val data: SendPaymentData) : SendPaymentResult()
+    object AlreadyPaid : SendPaymentResult()
+    object Pending : SendPaymentResult()
+    class Failure(val message: String) : SendPaymentResult()
 }

--- a/app/src/main/java/xyz/lilsus/papp/domain/repository/WalletRepository.kt
+++ b/app/src/main/java/xyz/lilsus/papp/domain/repository/WalletRepository.kt
@@ -2,7 +2,9 @@ package xyz.lilsus.papp.domain.repository
 
 import xyz.lilsus.papp.common.Invoice
 import xyz.lilsus.papp.domain.model.SendPaymentResult
+import xyz.lilsus.papp.domain.model.config.WalletTypeEntry
 
 interface WalletRepository {
+    val walletType: WalletTypeEntry
     suspend fun payBolt11Invoice(bolt11Invoice: Invoice): SendPaymentResult
 }

--- a/app/src/main/java/xyz/lilsus/papp/domain/use_case/wallets/PayInvoiceUseCase.kt
+++ b/app/src/main/java/xyz/lilsus/papp/domain/use_case/wallets/PayInvoiceUseCase.kt
@@ -5,22 +5,22 @@ import kotlinx.coroutines.flow.flow
 import xyz.lilsus.papp.common.Invoice
 import xyz.lilsus.papp.common.Resource
 import xyz.lilsus.papp.domain.model.SendPaymentResult
+import xyz.lilsus.papp.domain.model.config.WalletTypeEntry
 import xyz.lilsus.papp.domain.repository.WalletRepository
 
 class PayInvoiceUseCase(private val repository: WalletRepository?) {
-    fun execute(invoice: Invoice): Flow<Resource<SendPaymentResult>> = flow {
-        emit(Resource.Loading())
-        if (repository != null) {
-            try {
-                val res = repository.payBolt11Invoice(invoice)
-                emit(Resource.Success(res))
-            } catch (e: Exception) {
-                emit(Resource.Error(message = "Something went wrong...\n${e.message}"))
+    operator fun invoke(invoice: Invoice): Flow<Resource<Pair<SendPaymentResult, WalletTypeEntry>>> =
+        flow {
+            emit(Resource.Loading())
+            if (repository != null) {
+                try {
+                    val res = repository.payBolt11Invoice(invoice)
+                    emit(Resource.Success(Pair(res, repository.walletType)))
+                } catch (e: Exception) {
+                    emit(Resource.Error(message = "Something went wrong...\n${e.message}"))
+                }
+            } else {
+                emit(Resource.Error(message = "No active wallet configured"))
             }
-        } else {
-            emit(Resource.Error(message = "No active wallet configured"))
         }
-
-
-    }
 }

--- a/app/src/main/java/xyz/lilsus/papp/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/xyz/lilsus/papp/presentation/main/MainViewModel.kt
@@ -61,11 +61,11 @@ class MainViewModel(val payUseCase: PayInvoiceUseCase) : ViewModel() {
     }
 
     fun pay(invoice: Invoice) {
-        payUseCase.execute(invoice).onEach { result ->
+        payUseCase(invoice).onEach { result ->
             _uiState.value = when (result) {
                 is Resource.Loading -> PaymentUiState.Loading
-                is Resource.Success -> PaymentUiState.Received(result.data!!)
-                is Resource.Error -> PaymentUiState.Error(result.message?.toString())
+                is Resource.Success -> PaymentUiState.Received(result.data.first)
+                is Resource.Error -> PaymentUiState.Error(result.message)
             }
         }.launchIn(viewModelScope)
     }

--- a/app/src/test/java/xyz/lilsus/papp/data/repository/blink/dto/PayInvoiceResponseTest.kt
+++ b/app/src/test/java/xyz/lilsus/papp/data/repository/blink/dto/PayInvoiceResponseTest.kt
@@ -1,0 +1,138 @@
+package xyz.lilsus.papp.data.repository.blink.dto
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import xyz.lilsus.papp.domain.model.SendPaymentResult
+import kotlin.math.abs
+
+class PayInvoiceResponseTest {
+    @Test
+    fun `parse PayInvoiceResponse with missing status correctly`() {
+        val responseMissingStatus = PayInvoiceResponse(
+            PayInvoiceData(
+                PaymentSendPayload(
+                    errors = emptyList(),
+                    status = null,
+                    transaction = null
+                )
+            )
+        )
+        val sendPaymentResult = responseMissingStatus.parse()
+        assertTrue(sendPaymentResult is SendPaymentResult.Failure)
+    }
+
+    @Test
+    fun `parse PayInvoiceResponse with ALREADY_PAID status correctly`() {
+        val responseAlreadyPaidStatus = PayInvoiceResponse(
+            PayInvoiceData(
+                PaymentSendPayload(
+                    errors = emptyList(),
+                    status = PaymentSendResult.ALREADY_PAID,
+                    transaction = null
+                )
+            )
+        )
+        val sendPaymentResult = responseAlreadyPaidStatus.parse()
+        assertTrue(sendPaymentResult is SendPaymentResult.AlreadyPaid)
+    }
+
+    @Test
+    fun `parse PayInvoiceResponse with PENDING status correctly`() {
+        val responsePendingStatus = PayInvoiceResponse(
+            PayInvoiceData(
+                PaymentSendPayload(
+                    errors = emptyList(),
+                    status = PaymentSendResult.PENDING,
+                    transaction = null
+                )
+            )
+        )
+        val sendPaymentResult = responsePendingStatus.parse()
+        assertTrue(sendPaymentResult is SendPaymentResult.Pending)
+    }
+
+    @Test
+    fun `parse PayInvoiceResponse with FAILURE status without errors correctly`() {
+        val responseFailureStatusWithoutErrors = PayInvoiceResponse(
+            PayInvoiceData(
+                PaymentSendPayload(
+                    errors = emptyList(),
+                    status = PaymentSendResult.FAILURE,
+                    transaction = null
+                )
+            )
+        )
+
+        var sendPaymentResult = responseFailureStatusWithoutErrors.parse()
+        assertTrue(sendPaymentResult is SendPaymentResult.Failure)
+    }
+
+    @Test
+    fun `parse PayInvoiceResponse with FAILURE status with errors correctly`() {
+        val responseFailureStatusWithErrors = PayInvoiceResponse(
+            PayInvoiceData(
+                PaymentSendPayload(
+                    errors = listOf(
+                        xyz.lilsus.papp.data.repository.blink.dto.Error(
+                            "69420",
+                            "error message",
+                            listOf("path0", "path1")
+                        )
+                    ),
+                    status = PaymentSendResult.FAILURE,
+                    transaction = null
+                )
+            )
+        )
+
+        val sendPaymentResult = responseFailureStatusWithErrors.parse()
+        assertTrue(sendPaymentResult is SendPaymentResult.Failure)
+    }
+
+    @Test
+    fun `parse PayInvoiceResponse with SUCCESS status but no transaction correctly`() {
+        val responseSuccessStatusNoTransaction = PayInvoiceResponse(
+            PayInvoiceData(
+                PaymentSendPayload(
+                    errors = emptyList(),
+                    status = PaymentSendResult.SUCCESS,
+                    transaction = null
+                )
+            )
+        )
+        val sendPaymentResult = responseSuccessStatusNoTransaction.parse()
+        assertTrue(sendPaymentResult is SendPaymentResult.Failure)
+    }
+
+    @Test
+    fun `parse PayInvoiceResponse with SUCCESS status correctly`() {
+        val transaction = Transaction(
+            direction = TxDirection.SEND,
+            memo = null,
+            settlementAmount = 420,
+            settlementFee = 69,
+            status = TxStatus.SUCCESS
+        )
+        val responseSuccessStatus = PayInvoiceResponse(
+            PayInvoiceData(
+                PaymentSendPayload(
+                    errors = emptyList(),
+                    status = PaymentSendResult.SUCCESS,
+                    transaction = transaction
+                )
+            )
+        )
+        val sendPaymentResult = responseSuccessStatus.parse()
+        assertTrue(sendPaymentResult is SendPaymentResult.Success)
+        val data = (sendPaymentResult as SendPaymentResult.Success).data
+        val amountPaidTotal = abs(transaction.settlementAmount) // 420
+        val feePaid = abs(transaction.settlementFee) // 69
+        val amountPaid = amountPaidTotal - feePaid // 351
+
+        assertEquals(amountPaid, data.amountPaid)
+        assertEquals(feePaid, data.feePaid)
+        assertNull(data.memo)
+    }
+}


### PR DESCRIPTION
Instead of putting the wallet type into the `SendPaymentResult` it is more elegant and more robust to add this as an attribute to the `WalletRepository` so each wallet can override it.

Also Unit Test `PayInvoiceResponse.parse`