### PR TITLE
data: Emit `null` for blank active wallet key

### DIFF
--- a/app/src/main/java/xyz/lilsus/papp/data/repository/WalletConfigRepositoryImpl.kt
+++ b/app/src/main/java/xyz/lilsus/papp/data/repository/WalletConfigRepositoryImpl.kt
@@ -21,10 +21,9 @@ class WalletConfigRepositoryImpl(
     private val dataStore: DataStore<WalletConfigStore>
 ) : WalletConfigRepository {
 
-    override val activeWalletKey =
-        dataStore.data.distinctUntilChangedBy { it.activeWalletKey }.map { walletConfigStore ->
-            walletConfigStore.activeWalletKey
-        }
+    override val activeWalletKeyOrNull =
+        dataStore.data.distinctUntilChangedBy { it.activeWalletKey }
+            .map { it.activeWalletKey.takeIf { key -> key.isNotBlank() } }
 
     override val activeWalletConfigOrNull =
         dataStore.data.distinctUntilChangedBy { it.activeWalletKey }.map { walletConfigStore ->

--- a/app/src/main/java/xyz/lilsus/papp/domain/repository/WalletConfigRepository.kt
+++ b/app/src/main/java/xyz/lilsus/papp/domain/repository/WalletConfigRepository.kt
@@ -7,7 +7,7 @@ import xyz.lilsus.papp.domain.model.config.WalletEntry
 typealias WalletKey = String
 
 interface WalletConfigRepository {
-    val activeWalletKey: Flow<WalletKey>
+    val activeWalletKeyOrNull: Flow<WalletKey?>
     val activeWalletConfigOrNull: Flow<WalletEntry?>
     val walletConfigList: Flow<List<WalletEntry>>
 


### PR DESCRIPTION
In case the active wallet key was not set yet, protobuf defaults to an empty / blank string. Instead of emitting this from the `activeWalletKey` flow, we rather want to emit `null` and change the name to `activeWalletKeyOrNull` so it is more clear.