### PR TITLE
domain/data: Refactor `WalletRepository` methods

### DIFF
--- a/app/src/main/java/xyz/lilsus/papp/data/repository/blink/BlinkWalletRepository.kt
+++ b/app/src/main/java/xyz/lilsus/papp/data/repository/blink/BlinkWalletRepository.kt
@@ -9,7 +9,7 @@ import com.apollographql.apollo.exception.ApolloNetworkException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import xyz.lilsus.papp.common.Bolt11Invoice
+import xyz.lilsus.papp.common.Invoice
 import xyz.lilsus.papp.common.Resource
 import xyz.lilsus.papp.domain.model.SendPaymentData
 import xyz.lilsus.papp.domain.model.WalletRepositoryError
@@ -74,10 +74,10 @@ class BlinkWalletRepository(
         return onSuccess(data)
     }
 
-    override suspend fun payBolt11Invoice(bolt11Invoice: Bolt11Invoice): Resource<SendPaymentData> {
+    override suspend fun payBolt11Invoice(bolt11Invoice: Invoice.Bolt11): Resource<SendPaymentData> {
         val mutation = LnInvoicePaymentSendMutation(
             LnInvoicePaymentInput(
-                paymentRequest = bolt11Invoice.encodedSafe,
+                paymentRequest = bolt11Invoice.bolt11.encodedSafe,
                 walletId = walletId
             )
         )
@@ -113,10 +113,10 @@ class BlinkWalletRepository(
         }
     }
 
-    override suspend fun probeBolt11PaymentFee(bolt11Invoice: Bolt11Invoice): Resource<Long> {
+    override suspend fun probeBolt11PaymentFee(bolt11Invoice: Invoice.Bolt11): Resource<Long> {
         val mutation = LnInvoiceFeeProbeMutation(
             LnInvoiceFeeProbeInput(
-                paymentRequest = bolt11Invoice.encodedSafe,
+                paymentRequest = bolt11Invoice.bolt11.encodedSafe,
                 walletId = walletId
             )
         )

--- a/app/src/main/java/xyz/lilsus/papp/domain/repository/WalletRepository.kt
+++ b/app/src/main/java/xyz/lilsus/papp/domain/repository/WalletRepository.kt
@@ -1,12 +1,12 @@
 package xyz.lilsus.papp.domain.repository
 
-import xyz.lilsus.papp.common.Bolt11Invoice
+import xyz.lilsus.papp.common.Invoice
 import xyz.lilsus.papp.common.Resource
 import xyz.lilsus.papp.domain.model.SendPaymentData
 import xyz.lilsus.papp.domain.model.config.WalletTypeEntry
 
 interface WalletRepository {
     val walletType: WalletTypeEntry
-    suspend fun payBolt11Invoice(bolt11Invoice: Bolt11Invoice): Resource<SendPaymentData>
-    suspend fun probeBolt11PaymentFee(bolt11Invoice: Bolt11Invoice): Resource<Long>
+    suspend fun payBolt11Invoice(bolt11Invoice: Invoice.Bolt11): Resource<SendPaymentData>
+    suspend fun probeBolt11PaymentFee(bolt11Invoice: Invoice.Bolt11): Resource<Long>
 }

--- a/app/src/main/java/xyz/lilsus/papp/domain/use_case/wallets/PayInvoiceUseCase.kt
+++ b/app/src/main/java/xyz/lilsus/papp/domain/use_case/wallets/PayInvoiceUseCase.kt
@@ -20,7 +20,7 @@ class PayInvoiceUseCase(private val repositoryFlow: StateFlow<WalletRepository?>
                 emit(Resource.Error(WalletRepositoryError.NoWalletConnected))
                 return@flow
             }
-            val result = repository.payBolt11Invoice(invoice.bolt11)
+            val result = repository.payBolt11Invoice(invoice)
                 .map { it to repository.walletType }
             emit(result)
         }

--- a/app/src/main/java/xyz/lilsus/papp/domain/use_case/wallets/ProbeFeeUseCase.kt
+++ b/app/src/main/java/xyz/lilsus/papp/domain/use_case/wallets/ProbeFeeUseCase.kt
@@ -17,7 +17,7 @@ class ProbeFeeUseCase(
         val repository = repositoryFlow.value
             ?: return Resource.Error(WalletRepositoryError.NoWalletConnected)
 
-        val result = repository.probeBolt11PaymentFee(invoice.bolt11)
+        val result = repository.probeBolt11PaymentFee(invoice)
             .map { it to repository.walletType }
         return result
     }

--- a/app/src/test/java/xyz/lilsus/papp/data/repository/blink/BlinkWalletRepositoryTest.kt
+++ b/app/src/test/java/xyz/lilsus/papp/data/repository/blink/BlinkWalletRepositoryTest.kt
@@ -115,8 +115,8 @@ class BlinkWalletRepositoryTest {
         apolloClient.enqueueTestResponse(testSuccessFeeQuery, testSuccessFeeData)
 
         runBlocking {
-            val actualPay = repository.payBolt11Invoice(TEST_INVOICE_SUCCESS.bolt11)
-            val actualFee = repository.probeBolt11PaymentFee(TEST_INVOICE_SUCCESS.bolt11)
+            val actualPay = repository.payBolt11Invoice(TEST_INVOICE_SUCCESS)
+            val actualFee = repository.probeBolt11PaymentFee(TEST_INVOICE_SUCCESS)
             actualPay.shouldBeInstanceOf<Resource.Success<*>>()
             actualFee.shouldBeInstanceOf<Resource.Success<*>>()
             (actualPay.data).shouldBeInstanceOf<SendPaymentData.Success>()
@@ -153,7 +153,7 @@ class BlinkWalletRepositoryTest {
         apolloClient.enqueueTestResponse(testAlreadyPaidQuery, testAlreadyPaidDataNoTransaction)
 
         runBlocking {
-            val actual = repository.payBolt11Invoice(TEST_INVOICE_ALREADY_PAID.bolt11)
+            val actual = repository.payBolt11Invoice(TEST_INVOICE_ALREADY_PAID)
             actual.shouldBeInstanceOf<Resource.Success<*>>()
             (actual.data).shouldBeInstanceOf<SendPaymentData.AlreadyPaid>()
         }
@@ -178,7 +178,7 @@ class BlinkWalletRepositoryTest {
         apolloClient.enqueueTestResponse(testPendingQuery, testPendingData)
 
         runBlocking {
-            val actual = repository.payBolt11Invoice(TEST_INVOICE_PENDING.bolt11)
+            val actual = repository.payBolt11Invoice(TEST_INVOICE_PENDING)
             actual.shouldBeInstanceOf<Resource.Success<*>>()
             (actual.data).shouldBeInstanceOf<SendPaymentData.Pending>()
         }
@@ -203,7 +203,7 @@ class BlinkWalletRepositoryTest {
         apolloClient.enqueueTestResponse(testFailureQuery, testFailureData)
 
         runBlocking {
-            val actual = repository.payBolt11Invoice(TEST_INVOICE_FAILURE.bolt11)
+            val actual = repository.payBolt11Invoice(TEST_INVOICE_FAILURE)
             actual.shouldBeInstanceOf<Resource.Error>()
             (actual.error).shouldBeInstanceOf<WalletRepositoryError.WalletError>()
             actual.error.message.shouldNotBeNull()
@@ -230,7 +230,7 @@ class BlinkWalletRepositoryTest {
         apolloClient.enqueueTestResponse(testUnknownQuery, testUnknownData)
 
         runBlocking {
-            val actual = repository.payBolt11Invoice(TEST_INVOICE_FAILURE.bolt11)
+            val actual = repository.payBolt11Invoice(TEST_INVOICE_FAILURE)
             actual.shouldBeInstanceOf<Resource.Error>()
             (actual.error).shouldBeInstanceOf<WalletRepositoryError.UnexpectedError>()
         }
@@ -252,7 +252,7 @@ class BlinkWalletRepositoryTest {
         )
         apolloClient.enqueueTestResponse(testSuccessFeeQuery, testSuccessFeeDataNoAmount)
         runBlocking {
-            val actual = repository.probeBolt11PaymentFee(TEST_INVOICE_SUCCESS.bolt11)
+            val actual = repository.probeBolt11PaymentFee(TEST_INVOICE_SUCCESS)
             actual.shouldBeInstanceOf<Resource.Error>()
             (actual.error).shouldBeInstanceOf<WalletRepositoryError.UnexpectedError>()
         }
@@ -271,11 +271,11 @@ class BlinkWalletRepositoryTest {
             apolloMockServer.enqueue(mockedHttpResponse)
             apolloMockServer.enqueue(mockedHttpResponse)
 
-            val payResult = repository.payBolt11Invoice(TEST_INVOICE_FAILURE.bolt11)
+            val payResult = repository.payBolt11Invoice(TEST_INVOICE_FAILURE)
             payResult.shouldBeInstanceOf<Resource.Error>()
             payResult.error.shouldBeInstanceOf<WalletRepositoryError.AuthenticationError>()
 
-            val probeResult = repository.probeBolt11PaymentFee(TEST_INVOICE_FAILURE.bolt11)
+            val probeResult = repository.probeBolt11PaymentFee(TEST_INVOICE_FAILURE)
             probeResult.shouldBeInstanceOf<Resource.Error>()
             probeResult.error.shouldBeInstanceOf<WalletRepositoryError.AuthenticationError>()
         }
@@ -294,11 +294,11 @@ class BlinkWalletRepositoryTest {
             apolloMockServer.enqueue(mockedHttpResponse)
             apolloMockServer.enqueue(mockedHttpResponse)
 
-            val payResult = repository.payBolt11Invoice(TEST_INVOICE_FAILURE.bolt11)
+            val payResult = repository.payBolt11Invoice(TEST_INVOICE_FAILURE)
             payResult.shouldBeInstanceOf<Resource.Error>()
             payResult.error.shouldBeInstanceOf<WalletRepositoryError.ServerError>()
 
-            val probeResult = repository.probeBolt11PaymentFee(TEST_INVOICE_FAILURE.bolt11)
+            val probeResult = repository.probeBolt11PaymentFee(TEST_INVOICE_FAILURE)
             probeResult.shouldBeInstanceOf<Resource.Error>()
             probeResult.error.shouldBeInstanceOf<WalletRepositoryError.ServerError>()
         }
@@ -311,11 +311,11 @@ class BlinkWalletRepositoryTest {
             // Shutting down the server will cause a network exception
             apolloMockServer.close()
 
-            val payResult = repository.payBolt11Invoice(TEST_INVOICE_FAILURE.bolt11)
+            val payResult = repository.payBolt11Invoice(TEST_INVOICE_FAILURE)
             payResult.shouldBeInstanceOf<Resource.Error>()
             payResult.error.shouldBeInstanceOf<WalletRepositoryError.NetworkError>()
 
-            val probeResult = repository.probeBolt11PaymentFee(TEST_INVOICE_FAILURE.bolt11)
+            val probeResult = repository.probeBolt11PaymentFee(TEST_INVOICE_FAILURE)
             probeResult.shouldBeInstanceOf<Resource.Error>()
             probeResult.error.shouldBeInstanceOf<WalletRepositoryError.NetworkError>()
         }


### PR DESCRIPTION
Refactor the `WalletRefactory` interface methods to take `Invoice.Bolt11` as arguements instead of the `Bolt11Invoice` that is contained in them. This also indicates that the `Bolt11Invoice` class is probably not really usefull anymore and can be consolidated into the `Invoice` type/class as its sole purpose was to "guard" the constructor so that `encodedSafe` was always guaranteed to be valid eventhough its just a raw string.