### PR TITLE
presentation: Fix image analysis use case

### DIFF
--- a/app/src/main/java/xyz/lilsus/papp/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/xyz/lilsus/papp/presentation/main/MainViewModel.kt
@@ -101,7 +101,7 @@ class MainViewModel(
                                 // native sensor aspect ratio which is 4:3.
                                 ResolutionStrategy(
                                     Size(1920, 1440),
-                                    ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER,
+                                    ResolutionStrategy.FALLBACK_RULE_CLOSEST_LOWER,
                                 )
                             )
                             .build()


### PR DESCRIPTION
Fix image analysis use case resolution strategy by setting the fallback strategy to "closest lower" instead of "closest higher" so the app does not crash on less powerful devices.